### PR TITLE
swap order of loops in BilFile.read_bands()

### DIFF
--- a/spectral/io/bilfile.py
+++ b/spectral/io/bilfile.py
@@ -139,19 +139,18 @@ class BilFile(SpyFile, MemmapFile):
 
         arr = numpy.empty((self.nrows, self.ncols, len(bands)), self.dtype)
 
-        for j in range(len(bands)):
-
+        for i in range(self.nrows):
             vals = array('b')
-            offset = self.offset + (bands[j]) * self.sample_size * self.ncols
+            row_offset = self.offset + i * (self.sample_size * self.nbands *
+                                            self.ncols)
 
-            # Pixel format is BIL, so read an entire line at  time.
-            for i in range(self.nrows):
-                f.seek(offset + i * self.sample_size * self.nbands *
-                       self.ncols, 0)
+            # Pixel format is BIL, so read an entire line at a time.
+            for j in range(len(bands)):
+                f.seek(row_offset + bands[j] * self.sample_size * self.ncols, 0)
                 vals.fromfile(f, self.ncols * self.sample_size)
 
-            band = numpy.fromstring(vals.tostring(), dtype=self.dtype)
-            arr[:, :, j] = band.reshape((self.nrows, self.ncols))
+            frame = numpy.fromstring(vals.tostring(), dtype=self.dtype)
+            arr[i, :, :] = frame.reshape((len(bands), self.ncols)).transpose()
 
         if self.scale_factor != 1:
             return arr / float(self.scale_factor)


### PR DESCRIPTION
This branch switches the inner and outer loops in the `read_bands()` function for BIL files.  

I profiled the change by loading two different sets of bands using memmap, the current implementation, and the new loop order.  I did the tests on an internal SSD and a USB 3.0 drive.  Between tests I flushed the disk cache using `sync && echo 3 | sudo tee /proc/sys/vm/drop_caches`.   All times are averages of three runs, in seconds, in wall time (`time.time()`).

```
loading all 200 bands       SSD  USB drive
with memmap:               28.6   80.9
original loop order:        8.0   62.5
revised loop order:         2.6   20.1

loading bands [0,100,219]   SSD  USB drive
with memmap:                1.2   19.3
original loop order:        1.2   19.1
revised loop order:         1.3    9.9
```

I'd be curious to know if this is similar to the performance you see with memmap.  If so, maybe memmap should not be used for BIL or BIP `read_bands()`?
