### PR TITLE
Image array indexing

### DIFF
--- a/spectral/spectral.py
+++ b/spectral/spectral.py
@@ -298,7 +298,8 @@ class ImageArray(numpy.ndarray, Image):
         self.interleave = 2 # bip
 
     def __repr__(self):
-        return numpy.asarray(self).__str__()
+        lst = numpy.array2string(numpy.asarray(self), prefix="ImageArray(")
+        return "{}({}, dtype={})".format('ImageArray', lst, self.dtype.name)
 
     def __getitem__(self, args):
         # Duplicate the indexing behavior of SpyFile.  If args is iterable

--- a/spectral/spectral.py
+++ b/spectral/spectral.py
@@ -306,27 +306,26 @@ class ImageArray(numpy.ndarray, Image):
         # scalars, then the scalars need to be replaced with slices.
         import numbers
 
-        def parent_getitem(args):
-            result = super(ImageArray, self).__getitem__(args)
-            if isinstance(result, ImageArray):
-                return numpy.asarray(result)
-            else:
-                return result
-
         try:
             iterator = iter(args)
         except TypeError:
             if isinstance(args, numbers.Number):
-                updated_args = slice(args, args+1)
+                if args == -1:
+                    updated_args = slice(args, None)
+                else:
+                    updated_args = slice(args, args+1)
             else:
                 updated_args = args
-            return parent_getitem(updated_args)
+            return self._parent_getitem(updated_args)
 
         keep_original_args = True
         updated_args = []
         for arg in iterator:
             if isinstance(arg, numbers.Number):
-                updated_args.append(slice(arg, arg+1))
+                if arg == -1:
+                    updated_args.append(slice(arg, None))
+                else:
+                    updated_args.append(slice(arg, arg+1))
             elif isinstance(arg, numpy.bool_):
                 updated_args.append(arg)
             else:
@@ -338,7 +337,10 @@ class ImageArray(numpy.ndarray, Image):
         else:
             updated_args = tuple(updated_args)
 
-        return parent_getitem(updated_args)
+        return self._parent_getitem(updated_args)
+
+    def _parent_getitem(self, args):
+        return numpy.ndarray.__getitem__(self, args)
 
     def read_band(self, i):
         '''

--- a/spectral/spectral.py
+++ b/spectral/spectral.py
@@ -397,6 +397,21 @@ class ImageArray(numpy.ndarray, Image):
         s += '\tData format:  %8s' % self.dtype.name
         return s
 
+    def __array_wrap__(self, out_arr, context=None):
+        # The ndarray __array_wrap__ causes ufunc results to be of type
+        # ImageArray.  Instead, return a plain ndarray.
+        return out_arr
+
+    # Some methods do not call __array_wrap__ and will return an ImageArray.
+    # Currently, these need to be overridden individually or with
+    # __getattribute__ magic.
+
+    def __getattribute__(self, name):
+        if ((name in numpy.ndarray.__dict__) and
+            (name not in ImageArray.__dict__)):
+            return getattr(numpy.asarray(self), name)
+
+        return super(ImageArray, self).__getattribute__(name)
 
 def open_image(file):
     '''

--- a/spectral/spectral.py
+++ b/spectral/spectral.py
@@ -294,6 +294,8 @@ class ImageArray(numpy.ndarray, Image):
 
         Image.__init__(self, params, spyfile.metadata)
         self.bands = spyfile.bands
+        self.filename = spyfile.filename
+        self.interleave = 2 # bip
 
     def __repr__(self):
         return self.__str__()
@@ -310,9 +312,36 @@ class ImageArray(numpy.ndarray, Image):
         '''For SpyFile compatibility. Equivlalent to arr[row, col]'''
         return numpy.asarray(self[row, col])
 
+    def read_subregion(self, row_bounds, col_bounds, bands=None):
+        '''
+        For SpyFile compatibility.
+
+        Equivalent to arr[slice(*row_bounds), slice(*col_bounds), bands],
+        selecting all bands if none are specified.
+        '''
+        if bands:
+            return numpy.asarray(self[slice(*row_bounds),
+                                      slice(*col_bounds),
+                                      bands])
+        else:
+            return numpy.asarray(self[slice(*row_bounds),
+                                      slice(*col_bounds)])
+
+    def read_subimage(self, rows, cols, bands=None):
+        '''
+        For SpyFile compatibility.
+
+        Equivalent to arr[rows][:, cols][:, :, bands], selecting all bands if
+        none are specified.
+        '''
+        if bands:
+            return numpy.asarray(self[rows][:, cols][:, :, bands])
+        else:
+            return numpy.asarray(self[rows][:, cols])
+
     def read_datum(self, i, j, k):
         '''For SpyFile compatibility. Equivlalent to arr[i, j, k]'''
-        return np.asscalar(self[i, j, k])
+        return numpy.asscalar(self[i, j, k])
 
     def load(self):
         '''For compatibility with SpyFile objects. Returns self'''

--- a/spectral/tests/spyfile.py
+++ b/spectral/tests/spyfile.py
@@ -163,7 +163,24 @@ class SpyFileTest(SpyTest):
     def test_load(self):
         (i, j, k) = self.datum
         data = self.image.load()
+        simg = self.image
         assert_almost_equal(data[i, j, k], self.value)
+        assert_almost_equal(data.read_band(0),
+                            simg.read_band(0))
+        assert_almost_equal(data.read_bands([0, 1]),
+                            simg.read_bands([0, 1]))
+        assert_almost_equal(data.read_pixel(1, 2),
+                            simg.read_pixel(1, 2))
+        assert_almost_equal(data.read_subregion([0, 3], [1, 2]),
+                            simg.read_subregion([0, 3], [1, 2]))
+        assert_almost_equal(data.read_subregion([0, 3], [1, 2], [0, 1]),
+                            simg.read_subregion([0, 3], [1, 2], [0, 1]))
+        assert_almost_equal(data.read_subimage([0, 2, 4], [6, 3]),
+                            simg.read_subimage([0, 2, 4], [6, 3]))
+        assert_almost_equal(data.read_subimage([0, 2, 4], [6, 3], [0, 1]),
+                            simg.read_subimage([0, 2, 4], [6, 3], [0, 1]))
+        assert_almost_equal(data.read_datum(1,2,8),
+                            simg.read_datum(1,2,8))
 
     def test_getitem_i_j_k(self):
         (i, j, k) = self.datum

--- a/spectral/tests/spyfile.py
+++ b/spectral/tests/spyfile.py
@@ -175,6 +175,8 @@ class SpyFileTest(SpyTest):
         load_assert(data[:, 0, 0], spyf[:, 0, 0])
         load_assert(data[0, 0, 0], spyf[0, 0, 0])
         load_assert(data[0, 0], spyf[0, 0])
+        load_assert(data[-1, -1, -1], spyf[-1, -1, -1])
+        load_assert(data[-1, -3:-1], spyf[-1, -3:-1])
         load_assert(data[(6, 25)], spyf[(6, 25)])
 
         # The following test would currently fail, because

--- a/spectral/tests/spyfile.py
+++ b/spectral/tests/spyfile.py
@@ -196,6 +196,14 @@ class SpyFileTest(SpyTest):
                     spyf.read_subimage([0, 2], [6, 3], [0, 1]))
         load_assert(data.read_datum(1,2,8), spyf.read_datum(1,2,8))
 
+        import spectral
+        ufunc_result = data + 1
+        assert isinstance(ufunc_result, np.ndarray)
+        assert not isinstance(ufunc_result, type(data))
+        non_ufunc_result = data.diagonal()
+        assert isinstance(non_ufunc_result, np.ndarray)
+        assert not isinstance(non_ufunc_result, type(data))
+
     def test_getitem_i_j_k(self):
         (i, j, k) = self.datum
         assert_almost_equal(self.image[i, j, k], self.value)


### PR DESCRIPTION
This fixes #32, and also fixes some SpyFile behavior and adds additional enhancements to ImageArray.  

In particular, one change to ImageArray in this patch is that methods and numpy ufuncs always return a numpy ndarray instead of another ImageArray.  This is because many times (always?) these results lost their association with the original image that gave the quality of being ImageArrays.  For example, things like `image_array.diagonal()`, `image_array.mean(axis=2)`, or `image_array[0, 0, :]` would previously return other ImageArrays.  This doesn't make semantic sense, plus some attributes were wrong or were not set (`nrows`, `bands`, etc.).  Returning an ndarray gets around these issues, and also makes the return type consistent with indexing and `read_*` methods in SpyFile. 
