### PR TITLE
Add asarray method to ImageArray and SpyFile

### DIFF
--- a/spectral/io/spyfile.py
+++ b/spectral/io/spyfile.py
@@ -806,6 +806,24 @@ class MemmapFile(object):
             return np.transpose(memmap, interleave_transpose(src_inter,
                                                              dst_inter))
 
+    def asarray(self, writable=False):
+        '''Returns an object with a standard numpy array interface.
+
+        The function returns a numpy memmap created with the
+        `open_memmap` method.
+
+        This function is for compatibility with ImageArray objects.
+
+        Keyword Arguments:
+
+            `writable` (bool, default False):
+
+                If `writable` is True, modifying values in the returned
+                memmap will result in corresponding modification to the
+                image data file.
+        '''
+        return self.open_memmap(writable=writable)
+
 def interleave_transpose(int1, int2):
     '''Returns the 3-tuple of indices to transpose between interleaves.
 

--- a/spectral/spectral.py
+++ b/spectral/spectral.py
@@ -392,6 +392,28 @@ class ImageArray(numpy.ndarray, Image):
         '''For compatibility with SpyFile objects. Returns self'''
         return self
 
+    def asarray(self, writable=False):
+        '''Returns an object with a standard numpy array interface.
+
+        The return value is the same as calling `numpy.asarray`, except
+        that the array is not writable by default to match the behavior
+        of `SpyFile.asarray`.
+
+        This function is for compatibility with SpyFile objects.
+
+        Keyword Arguments:
+
+            `writable` (bool, default False):
+
+                If `writable` is True, modifying values in the returned
+                array will result in corresponding modification to the
+                ImageArray object.
+        '''
+        arr = numpy.asarray(self)
+        if not writable:
+            arr.setflags(write=False)
+        return arr
+
     def info(self):
         s = '\t# Rows:         %6d\n' % (self.nrows)
         s += '\t# Samples:      %6d\n' % (self.ncols)


### PR DESCRIPTION
Sometimes, for both `ImageArray` and `SpyFile`, you need a way to bypass the SPy-style indexing and get to a numpy object.  Rather than having functions test the type of a the data, the `asarray` methods in this commit return an analogous interface for both classes.