### PR TITLE
tostring() has been deprecated

### DIFF
--- a/spectral/graphics/hypercube.py
+++ b/spectral/graphics/hypercube.py
@@ -277,7 +277,7 @@ class HypercubeWindow(wx.Frame, SpyWindow):
         (a, b, c) = data.shape
         texSizes = [(b, a), (b, c), (a, c), (b, c), (a, c), (b, a)]
         for i in range(len(images)):
-            img = images[i].tostring("raw", "RGBX", 0, -1)
+            img = images[i].tobytes("raw", "RGBX", 0, -1)
             (dim_x, dim_y) = images[i].size
             texImages.append(img)
 


### PR DESCRIPTION
Solves the error : 

```
Exception: tostring() has been removed. Please call tobytes() instead.
```