### PR TITLE
ISSUE-56 spylab.py throws AttributeError: 'dict' object has no attribute 'has_key'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 *#
 *~
 TAGS
+.project
+.pydevproject

--- a/spectral/graphics/spypylab.py
+++ b/spectral/graphics/spypylab.py
@@ -1126,7 +1126,7 @@ class ImageView(object):
         else:
             interp = self.interpolation
         s += '  {0:<20}:  {1}\n'.format("Interpolation", interp)
-        if meta.has_key('rgb range'):
+        if 'rgb range' in meta:
             s += '  {0:<20}:\n'.format("RGB data limits")
             for (c, r) in zip('RGB', meta['rgb range']):
                 s += '    {0}: {1}\n'.format(c, str(r))


### PR DESCRIPTION
Hi @tboggs this is a cleaner PR. Thank you for attending to the python3 branch.