### PR TITLE
Add denoising methods to class PrincipalComponents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+dist: trusty
 python:
   - "2.6"
   - "2.7"

--- a/spectral/algorithms/algorithms.py
+++ b/spectral/algorithms/algorithms.py
@@ -576,6 +576,15 @@ def principal_components(image):
         `reduce`:
 
             A method to reduce the number of eigenvalues.
+
+        `denoise`:
+
+            A callable function to denoise data using a reduced set of
+            principal components.
+
+        `get_denoising_transform`:
+
+            A callable function that returns a function for denoising data.
     '''
     from numpy import sqrt, sum
 


### PR DESCRIPTION
Hi there!

I wrote a couple of denoising methods into the PrincipalComponents class, with a format similar to the ones in the MNFResult class. I'm currently using MNF on some data I'm working on, and I find it useful to be able to swiftly compare the MNF denoising to an equivalent PCA denoising.

This is my first ever pull request, just so you know, so I hope I'm going about this in basically the right way. Tips are welcome.

Thanks!
--Gemma