### PR TITLE
Use frombuffer instead of fromstring (deprecated)

### DIFF
--- a/spectral/io/spyfile.py
+++ b/spectral/io/spyfile.py
@@ -235,7 +235,7 @@ class SpyFile(Image):
         self.fid.seek(self.offset)
         data.fromfile(self.fid, self.nrows * self.ncols *
                       self.nbands * self.sample_size)
-        npArray = np.fromstring(tobytes(data), dtype=self.dtype)
+        npArray = np.frombuffer(tobytes(data), dtype=self.dtype)
         if self.interleave == spectral.BIL:
             npArray.shape = (self.nrows, self.nbands, self.ncols)
             npArray = npArray.transpose([0, 2, 1])


### PR DESCRIPTION
The function numpy.fromstring has been deprecated, so use frombuffer instead.