### PR TITLE
Use np.frombuffer instead of np.fromstring

### DIFF
--- a/spectral/io/bilfile.py
+++ b/spectral/io/bilfile.py
@@ -82,7 +82,7 @@ class BilFile(SpyFile, MemmapFile):
                    self.ncols, 0)
             vals.fromfile(f, self.ncols * self.sample_size)
 
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape((self.nrows, self.ncols))
 
         if self.scale_factor != 1:
@@ -132,7 +132,7 @@ class BilFile(SpyFile, MemmapFile):
                 f.seek(row_offset + bands[j] * self.sample_size * self.ncols, 0)
                 vals.fromfile(f, self.ncols * self.sample_size)
 
-            frame = np.fromstring(tobytes(vals), dtype=self.dtype)
+            frame = np.frombuffer(tobytes(vals), dtype=self.dtype)
             arr[i, :, :] = frame.reshape((len(bands), self.ncols)).transpose()
 
         if self.scale_factor != 1:
@@ -180,7 +180,7 @@ class BilFile(SpyFile, MemmapFile):
             f.seek(offset + i * sample_size * ncols, 0)
             vals.fromfile(f, sample_size)
 
-        pixel = np.fromstring(tobytes(vals), dtype=self.dtype)
+        pixel = np.frombuffer(tobytes(vals), dtype=self.dtype)
 
         if self.scale_factor != 1:
             return pixel / float(self.scale_factor)
@@ -259,7 +259,7 @@ class BilFile(SpyFile, MemmapFile):
             for j in bands:
                 f.seek(rowPos + j * ncols * sampleSize, 0)
                 vals.fromfile(f, nSubCols * sampleSize)
-            subArray = np.fromstring(tobytes(vals), dtype=self.dtype)
+            subArray = np.frombuffer(tobytes(vals), dtype=self.dtype)
             subArray = subArray.reshape((nSubBands, nSubCols))
             arr[i - row_bounds[0], :, :] = np.transpose(subArray)
 
@@ -340,7 +340,7 @@ class BilFile(SpyFile, MemmapFile):
                            j * d_col +
                            k * d_band, 0)
                     vals.fromfile(f, sample_size)
-        subArray = np.fromstring(tobytes(vals), dtype=self.dtype)
+        subArray = np.frombuffer(tobytes(vals), dtype=self.dtype)
         subArray = subArray.reshape((nSubRows, nSubCols, nSubBands))
 
         if self.scale_factor != 1:
@@ -378,5 +378,5 @@ class BilFile(SpyFile, MemmapFile):
         self.fid.seek(self.offset + i * d_row + j * d_col + k * d_band, 0)
         vals = array.array(byte_typecode)
         vals.fromfile(self.fid, self.sample_size)
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         return arr.tolist()[0] / float(self.scale_factor)

--- a/spectral/io/bipfile.py
+++ b/spectral/io/bipfile.py
@@ -83,7 +83,7 @@ class BipFile(SpyFile, MemmapFile):
             f.seek(delta, 1)
         vals.fromfile(f, sample_size)
 
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape(self.nrows, self.ncols)
 
         if self.scale_factor != 1:
@@ -138,7 +138,7 @@ class BipFile(SpyFile, MemmapFile):
             for j in range(len(bands)):
                 f.seek(pixelOffset + delta_b[j], 0)        # Next band
                 vals.fromfile(f, sample_size)
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape(self.nrows, self.ncols, len(bands))
 
         if self.scale_factor != 1:
@@ -180,7 +180,7 @@ class BipFile(SpyFile, MemmapFile):
         # Pixel format is BIP so read entire pixel.
         vals.fromfile(f, self.nbands * self.sample_size)
 
-        pixel = np.fromstring(tobytes(vals), dtype=self.dtype)
+        pixel = np.frombuffer(tobytes(vals), dtype=self.dtype)
 
         if self.scale_factor != 1:
             return pixel / float(self.scale_factor)
@@ -269,7 +269,7 @@ class BipFile(SpyFile, MemmapFile):
                     for k in range(len(bands)):
                         f.seek(pixelPos + delta_b[k], 0)    # Next band
                         vals.fromfile(f, sample_size)
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape(nSubRows, nSubCols, nSubBands)
 
         if self.scale_factor != 1:
@@ -354,7 +354,7 @@ class BipFile(SpyFile, MemmapFile):
                                k * d_band, 0)
                         vals.fromfile(f, sample_size)
 
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape(nSubRows, nSubCols, nSubBands)
 
         if self.scale_factor != 1:
@@ -391,5 +391,5 @@ class BipFile(SpyFile, MemmapFile):
                * (self.nbands * (i * self.ncols + j) + k), 0)
         # Pixel format is BIP so read entire pixel.
         vals.fromfile(f, self.sample_size)
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         return arr.tolist()[0] / float(self.scale_factor)

--- a/spectral/io/bsqfile.py
+++ b/spectral/io/bsqfile.py
@@ -81,7 +81,7 @@ class BsqFile(SpyFile, MemmapFile):
         f.seek(offset, 0)
         vals.fromfile(f, self.nrows * self.ncols * self.sample_size)
 
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape(self.nrows, self.ncols)
 
         if self.scale_factor != 1:
@@ -131,7 +131,7 @@ class BsqFile(SpyFile, MemmapFile):
             f.seek(offset, 0)
             vals.fromfile(f, self.nrows * self.ncols * self.sample_size)
 
-            band = np.fromstring(tobytes(vals), dtype=self.dtype)
+            band = np.frombuffer(tobytes(vals), dtype=self.dtype)
             arr[:, :, j] = band.reshape(self.nrows, self.ncols)
 
         if self.scale_factor != 1:
@@ -185,7 +185,7 @@ class BsqFile(SpyFile, MemmapFile):
                    + col * sampleSize, 0)
             vals.fromfile(f, sampleSize)
 
-        pixel = np.fromstring(tobytes(vals), dtype=self.dtype)
+        pixel = np.frombuffer(tobytes(vals), dtype=self.dtype)
 
         if self.scale_factor != 1:
             return pixel / float(self.scale_factor)
@@ -268,7 +268,7 @@ class BsqFile(SpyFile, MemmapFile):
                        + j * rowSize
                        + colStartOffset, 0)
                 vals.fromfile(f, nSubCols * sampleSize)
-            subArray = np.fromstring(tobytes(vals),
+            subArray = np.frombuffer(tobytes(vals),
                                      dtype=self.dtype).reshape((nSubRows,
                                                                 nSubCols))
             arr[:, :, i] = subArray
@@ -357,7 +357,7 @@ class BsqFile(SpyFile, MemmapFile):
                            + rowOffset
                            + k * sampleSize, 0)
                     vals.fromfile(f, sampleSize)
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         arr = arr.reshape(nSubBands, nSubRows, nSubCols)
         arr = np.transpose(arr, (1, 2, 0))
 
@@ -399,5 +399,5 @@ class BsqFile(SpyFile, MemmapFile):
                          + j) * sampleSize, 0)
         vals = array.array(byte_typecode)
         vals.fromfile(self.fid, sampleSize)
-        arr = np.fromstring(tobytes(vals), dtype=self.dtype)
+        arr = np.frombuffer(tobytes(vals), dtype=self.dtype)
         return arr.tolist()[0] / float(self.scale_factor)

--- a/spectral/io/spyfile.py
+++ b/spectral/io/spyfile.py
@@ -201,7 +201,7 @@ class SpyFile(Image):
         self.fid.seek(self.offset)
         data.fromfile(self.fid, self.nrows * self.ncols *
                       self.nbands * self.sample_size)
-        npArray = np.fromstring(tobytes(data), dtype=self.dtype)
+        npArray = np.frombuffer(tobytes(data), dtype=self.dtype)
         if self.interleave == spy.BIL:
             npArray.shape = (self.nrows, self.nbands, self.ncols)
             npArray = npArray.transpose([0, 2, 1])


### PR DESCRIPTION
Done using: `find . -name '*.py' | xargs sed -i s/np\.fromstring/np\.frombuffer/g`.

```
------------------------------------------------------------------------
All 778 tests PASSED!
------------------------------------------------------------------------
```