### PR TITLE
Fix USGSDatabase._import_files to accept ASCIIdata_splib07a as direct input

### DIFF
--- a/spectral/database/usgs.py
+++ b/spectral/database/usgs.py
@@ -457,15 +457,36 @@ class USGSDatabase(SpectralDatabase):
         if not os.path.isdir(data_dir):
             raise Exception('Error: Invalid directory name specified.')
 
+        # Detect whether data_dir is already a sub-library directory
+        # (i.e., it contains Chapter* folders directly, as in ASCIIdata_splib07a/).
+        # This happens when the user passes the downloaded USGS folder directly,
+        # since the USGS download does not include a parent wrapper directory.
+        immediate_subdirs = [
+            d for d in os.listdir(data_dir)
+            if os.path.isdir(os.path.join(data_dir, d))
+        ]
+        is_sublibrary = any(d.startswith('Chapter') for d in immediate_subdirs)
+
+        if is_sublibrary:
+            sublib_dirs = [data_dir]
+            logger.info(
+                'data_dir "%s" appears to be a sub-library directory directly '
+                '(contains Chapter* subdirectories). Processing it as a single '
+                'sub-library.', data_dir
+            )
+        else:
+            sublib_dirs = [
+                os.path.join(data_dir, d)
+                for d in os.listdir(data_dir)
+                if os.path.isdir(os.path.join(data_dir, d))
+            ]
+
         num_sample_files = 0
         num_spectrometer_files = 0
         num_failed_sample_files = 0
         num_failed_spectromter_files = 0
 
-        for sublib in os.listdir(data_dir):
-            sublib_dir = os.path.join(data_dir, sublib)
-            if not os.path.isdir(sublib_dir):
-                continue
+        for sublib_dir in sublib_dirs:
 
             # Process instrument data one by one.
             for f in glob(sublib_dir + '/*.txt'):
@@ -495,15 +516,16 @@ class USGSDatabase(SpectralDatabase):
                         self._add_sample_data(spdata)
                         num_sample_files += 1
                     except Exception as e:
-                        logger.error(
-                            'Failed to import sample file %s', f)
+                        logger.error('Failed to import sample file %s', f)
                         logger.error(e)
                         num_failed_sample_files += 1
 
-        logger.info('Imported %d sample files and %d spectrometer files. '
-                    '%d failed sample files, and %d failed spectrometer files.',
-                    num_sample_files, num_spectrometer_files, num_failed_sample_files,
-                    num_failed_spectromter_files)
+        logger.info(
+            'Imported %d sample files and %d spectrometer files. '
+            '%d failed sample files, and %d failed spectrometer files.',
+            num_sample_files, num_spectrometer_files,
+            num_failed_sample_files, num_failed_spectromter_files
+        )
 
     def get_spectrum(self, sampleID):
         '''Returns a spectrum from the database.


### PR DESCRIPTION
## Problem

Calling:

```python
db = USGSDatabase.create("usgs_db.db", "ASCIIdata_splib07a")
```

produces an empty database. The log shows repeated errors:

*Failed to import spectrometer file ...
Could not assume measurement type for header line splib07a record=18244: alizarin_crimson (dk) gds780 asdfra aref*

**Root cause:** `_import_files` iterates over the immediate subdirectories of
`data_dir` and treats each one as a sub-library. When `data_dir` is
`ASCIIdata_splib07a/` directly, those subdirectories are `Chapter*` folders.
The code then calls `SpectrometerData.read_from_file()` on the sample `.txt`
files inside them, which fails because sample headers do not contain any of the
measurement-type keywords (`wavelength`, `bandpass`, etc.).

**Why this is common:** the USGS download delivers data as
`ASCIIdata_splib07a/Chapter*/...` with no parent wrapper directory. (https://www.sciencebase.gov/catalog/item/586e8c88e4b0f5ce109fccae)
Users naturally pass the downloaded folder directly.

## Fix

Detect whether `data_dir` itself already contains `Chapter*` subdirectories.
If so, treat it as a single sub-library rather than a parent container.
The detection is a one-liner and fully backward-compatible:

```python
is_sublibrary = any(d.startswith('Chapter') for d in immediate_subdirs)
```

## Layouts now supported

| `usgs_data_dir` | Layout | Works? |
|---|---|---|
| `ASCIIdata/` | `ASCIIdata/ASCIIdata_splib07a/Chapter*/` |  as before |
| `ASCIIdata_splib07a/` | `ASCIIdata_splib07a/Chapter*/` |  now fixed |

Verified with splib07a that both layouts produce a correctly populated database.