### PR TITLE
Update website in README to HTTPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Spectral Python (SPy)
 Spectral Python (SPy) is a pure Python module for processing hyperspectral image
 data (imaging spectroscopy data). It has functions for reading, displaying,
 manipulating, and classifying hyperspectral imagery. Full details about the
-package are on the `web site <http://spectralpython.net>`_.
+package are on the `web site <https://www.spectralpython.net/>`_.
 
 
 Installation Instructions


### PR DESCRIPTION
As the title implies, this PR changes the URL in the README file to use HTTPS instead of HTTP, which stops browsers from complaining. Since https://spectralpython.net/ does not redirect to the www subdomain, I've also updated the URL in the README to use https://www.spectralpython.net/.